### PR TITLE
Improve markup and spelling

### DIFF
--- a/home.html
+++ b/home.html
@@ -1,27 +1,19 @@
 <!DOCTYPE html>
 <html>
-
-  <head>
-    <link rel="stylesheet" type="text/css" href="css/home.css">
-    <title>The Broken Dialogue</title>
-  </head>
-  <body>
-
-
-    <div>
-      It's important to know if we are racist. Take this simple questionaire to help find out.
-    </div>
-    <div>
-      Are you white?
-    </div>
-    <div>
-      <a href="white-person.html">Yes</a>
-    </div>
-    <div>
-      <a href="not-white-person.html">No</a>
-    </div>
-
-
-  </body>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <title>The Broken Dialogue</title>
+  <link rel="stylesheet" type="text/css" href="css/home.css">
+</head>
+<body>
+  <header>
+    <h1 class="title">The Broken Dialogue</h1>
+  </header>
+  <p>It’s important to know if we are racist. Take this simple questionnaire to help find out.</p>
+  <p>Are you white?</p>
+  <p><a href="white-person.html">Yes</a></p>
+  <p><a href="not-white-person.html">No</a></p>
+</body>
 </html>
-

--- a/white-person.html
+++ b/white-person.html
@@ -1,35 +1,23 @@
 <!DOCTYPE html>
 <html>
-
-  <head>
-    <link rel="stylesheet" type="text/css" href="css/white-person.css">
-    <title>The Broken Dialogue</title>
-  </head>
-  <body>
-
-
-    <div>
-      Yes! You're racist!
-    </div>
-    <div>
-      Today’s racism is much different than it was a few decades ago. While the KKK still exists, and people still believe Obama wasn’t born in America, modern-day racism is more subtle. Instead, of demonstrative and proud, the racism we face today is found in the back-of-the-minds of well-meaning people.
-    </div>
-    <div>
-      As a white person, we live our lives marked with opportunity and we are incapable of understanding the struggles men and women of color must deal with on a daily basis.
-    </div>
-    <div>
-      You may be thinking "I have black friends", or "I'm colorblind when it comes to people”. But these reactions do not address the real problem that we are participating in racism every time we fail to see it.
-    </div>
-    <div>
-      We cannot commit occasional acts of non-racism in order to not be racist.
-    </div>
-    <div>
-      But don’t worry! Just because we’ll never be able to sympathize with the plight of people of color doesn’t mean we can’t make a positive change.
-    </div>
-    <div>
-      What we have to do:
-      - Talk to other white people
-      - .... other stuff here....
-    </div>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <title>The Broken Dialogue</title>
+  <link rel="stylesheet" type="text/css" href="css/white-person.css">
+</head>
+<body>
+  <h1 id="yes-youre-racist">Yes! You’re racist!</h1>
+  <p>Today’s racism is much different than it was a few decades ago. While the KKK still exists, and people still believe Obama wasn’t born in America, modern-day racism is more subtle. Instead, of demonstrative and proud, the racism we face today is found in the back-of-the-minds of well-meaning people.</p>
+  <p>As a white person, we live our lives marked with opportunity and we are incapable of understanding the struggles men and women of color must deal with on a daily basis.</p>
+  <p>You may be thinking “I have black friends”, or “I’m colorblind when it comes to people”. But these reactions do not address the real problem that we are participating in racism every time we fail to see it.</p>
+  <p>We cannot commit occasional acts of non-racism in order to not be racist.</p>
+  <p>But don’t worry! Just because we’ll never be able to sympathize with the plight of people of color doesn’t mean we can’t make a positive change.</p>
+  <h2 id="what-we-have-to-do">What we have to do</h2>
+  <ul>
+    <li>Talk to other white people</li>
+    <li>…. other stuff here….</li>
+  </ul>
+</body>
 </html>


### PR DESCRIPTION
By adding a `<meta charset="utf-8">`, you get rendering of typographer's
quotes instead of wacky characters. It's also a wee bit more semantically correct to use `<p>` elements for paragraphs instead of `<div>` elements (which have no meaning [by definition](https://html.spec.whatwg.org/multipage/semantics.html#the-div-element)).

Also, correct the spelling of "questionnaire".
